### PR TITLE
Improve skill generation context handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,6 +70,225 @@ def open_browser():
     time.sleep(1.5)
     webbrowser.open('http://127.0.0.1:5000')
 
+
+def _extract_summary_highlights(content, max_chars=5000):
+    lines = content.splitlines()
+    selected = []
+    current_len = 0
+
+    def add_line(line):
+        nonlocal current_len
+        if not line:
+            return
+        extra = len(line) + 1
+        if current_len + extra > max_chars:
+            return
+        selected.append(line)
+        current_len += extra
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(('#', '##', '###', '####', '-', '*', '>', '|')):
+            add_line(stripped)
+
+    if current_len < max_chars:
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith(('#', '##', '###', '####', '-', '*', '>', '|')):
+                continue
+            add_line(stripped[:300])
+            if current_len >= max_chars:
+                break
+
+    if not selected:
+        return content[:max_chars]
+
+    result = "\n".join(selected)
+    if len(result) < len(content):
+        result += "\n[Truncated for context budget]"
+    return result
+
+
+def _extract_key_sections(content, max_chars=8000):
+    key_heading_keywords = (
+        "核心", "关键", "关系", "经历", "事件", "人格", "语言", "行为",
+        "情绪", "设定", "背景", "成长", "矛盾", "identity", "relationship",
+        "speech", "behavior", "event", "background", "persona", "emotion"
+    )
+    lines = content.splitlines()
+    sections = []
+    current_heading = None
+    current_lines = []
+
+    def flush_section():
+        if current_heading is not None and current_lines:
+            sections.append((current_heading, "\n".join(current_lines).strip()))
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            flush_section()
+            current_heading = stripped
+            current_lines = [stripped]
+        elif current_heading is not None:
+            current_lines.append(line)
+
+    flush_section()
+
+    selected = []
+    used = 0
+    for heading, block in sections:
+        if not any(keyword.lower() in heading.lower() for keyword in key_heading_keywords):
+            continue
+        candidate = block.strip()
+        if not candidate:
+            continue
+        extra = len(candidate) + 2
+        if used + extra > max_chars:
+            remaining = max_chars - used
+            if remaining > 200:
+                selected.append(candidate[:remaining].rstrip() + "\n[Truncated key section]")
+            break
+        selected.append(candidate)
+        used += extra
+
+    if not selected:
+        return ""
+    return "\n\n".join(selected)
+
+
+def _build_skill_generation_context(summary_files, max_total_chars=45000, max_chars_per_file=3500):
+    compact_sections = []
+    used = 0
+
+    for file_path in summary_files:
+        if used >= max_total_chars:
+            break
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except Exception:
+            continue
+
+        section_budget = min(max_chars_per_file, max_total_chars - used)
+        if section_budget <= 0:
+            break
+        compact = _extract_summary_highlights(content, max_chars=section_budget)
+        section = f"=== {os.path.basename(file_path)} ===\n{compact}"
+        compact_sections.append(section)
+        used += len(section) + 2
+
+    return "\n\n".join(compact_sections)
+
+
+def _build_full_skill_generation_context(summary_files):
+    sections = []
+    for file_path in summary_files:
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except Exception:
+            continue
+        sections.append(f"=== {os.path.basename(file_path)} ===\n{content}")
+    return "\n\n".join(sections)
+
+
+def _head_tail_weighted_order(items):
+    ordered = []
+    left = 0
+    right = len(items) - 1
+    pattern = ("head", "tail", "tail")
+    step = 0
+
+    while left <= right:
+        direction = pattern[step % len(pattern)]
+        if direction == "head":
+            ordered.append(items[left])
+            left += 1
+        else:
+            ordered.append(items[right])
+            right -= 1
+        step += 1
+
+    return ordered
+
+
+def _build_prioritized_skill_generation_context(summary_files, target_total_chars=200000):
+    if not summary_files:
+        return ""
+
+    file_infos = []
+    for file_path in summary_files:
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            file_infos.append({
+                "path": file_path,
+                "name": os.path.basename(file_path),
+                "content": content,
+            })
+        except Exception:
+            continue
+
+    if not file_infos:
+        return ""
+    sections = []
+    used = 0
+
+    def add_section(name, body, suffix=None):
+        nonlocal used
+        if not body:
+            return False
+        label = f"=== {name}"
+        if suffix:
+            label += f" [{suffix}]"
+        label += " ===\n"
+        candidate = label + body
+        extra = len(candidate) + 2
+        if used + extra > target_total_chars:
+            remaining = target_total_chars - used
+            if remaining <= len(label) + 200:
+                return False
+            body_budget = remaining - len(label)
+            candidate = label + body[:body_budget].rstrip() + "\n[Truncated for context budget]"
+            extra = len(candidate) + 2
+        sections.append(candidate)
+        used += extra
+        return used < target_total_chars
+
+    prioritized_infos = _head_tail_weighted_order(file_infos)
+    full_preserve_count = min(3, len(prioritized_infos))
+
+    for item in prioritized_infos[:full_preserve_count]:
+        if not add_section(item["name"], item["content"], suffix="full head-tail weighted"):
+            return "\n\n".join(sections)
+
+    for item in prioritized_infos[full_preserve_count:]:
+        key_sections = _extract_key_sections(item["content"], max_chars=12000)
+        if key_sections:
+            if not add_section(item["name"], key_sections, suffix="key sections"):
+                return "\n\n".join(sections)
+
+    for item in prioritized_infos[full_preserve_count:]:
+        if used >= target_total_chars:
+            break
+        summary_budget = min(8000, max(2500, (target_total_chars - used) // max(1, len(file_infos))))
+        compact = _extract_summary_highlights(item["content"], max_chars=summary_budget)
+        add_section(item["name"], compact, suffix="compressed")
+
+    return "\n\n".join(sections)
+
+
+def _estimate_tokens_from_text(text):
+    if not text:
+        return 0
+    # Conservative rough estimate for mixed Chinese/Japanese/English content.
+    return max(1, len(text) // 2)
+
 def get_llm_client():
     data = request.json if request.is_json else {}
     baseurl = data.get('baseurl', '')
@@ -403,15 +622,35 @@ def generate_skills_folder(data):
                         summary_files.append(file_path)
     if not summary_files:
         return jsonify({'success': False, 'message': f'未找到角色 "{role_name}" 的归纳文件，请先完成归纳'})
-    all_summaries = []
-    for file_path in summary_files:
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-                all_summaries.append(f"=== {os.path.basename(file_path)} ===\n{content}")
-        except Exception as e:
-            pass
-    summaries_text = "\n\n".join(all_summaries)
+    raw_full_text = _build_full_skill_generation_context(summary_files)
+    raw_total_chars = len(raw_full_text)
+    raw_estimated_tokens = _estimate_tokens_from_text(raw_full_text)
+    context_limit_tokens = 128000
+    target_budget_tokens = 100000
+
+    if raw_estimated_tokens > context_limit_tokens:
+        target_budget_chars = target_budget_tokens * 2
+        summaries_text = _build_prioritized_skill_generation_context(
+            summary_files,
+            target_total_chars=target_budget_chars
+        )
+        context_mode = "compressed"
+    else:
+        summaries_text = raw_full_text
+        context_mode = "full"
+
+    if not summaries_text:
+        return jsonify({'success': False, 'message': f'未能读取角色 "{role_name}" 的归纳内容'})
+    compressed_chars = len(summaries_text)
+    estimated_tokens = _estimate_tokens_from_text(summaries_text)
+    compression_ratio = (compressed_chars / raw_total_chars) if raw_total_chars else 0
+    print(
+        f"[SkillGen] role={role_name} files={len(summary_files)} mode={context_mode} "
+        f"raw_chars={raw_total_chars} raw_estimated_tokens={raw_estimated_tokens} "
+        f"final_chars={compressed_chars} final_estimated_tokens={estimated_tokens} "
+        f"compression_ratio={compression_ratio:.2%} "
+        f"strategy={'head_tail_weighted_1_2_then_key_sections' if context_mode == 'compressed' else 'full_context'}"
+    )
     llm_interaction = get_llm_client()
     messages, tools = llm_interaction.generate_skills_folder_init(summaries_text, role_name, output_language, vndb_data)
     all_results = []

--- a/utils/llm_interaction.py
+++ b/utils/llm_interaction.py
@@ -273,7 +273,202 @@ DO NOT:
 - Confuse the character's voice with narrative description
 
 Additional instructions: {instruction}"""
+
+        if output_language:
+            lang_names = {"zh": "中文", "en": "English", "ja": "日本語"}
+            lang_name = lang_names.get(output_language, output_language)
+            system_prompt += f"""
+
+## OUTPUT LANGUAGE
+You MUST write ALL content in {lang_name}.
+- Character analysis: {lang_name}
+- All descriptions and summaries: {lang_name}
+ALL output must be in {lang_name}, regardless of the source text language."""
+
+        if vndb_data:
+            vndb_section = "\n\n## VNDB REFERENCE DATA (Use as authoritative source for basic info):\n"
+            if vndb_data.get('name'):
+                vndb_section += f"- Name: {vndb_data['name']}\n"
+            if vndb_data.get('original_name'):
+                vndb_section += f"- Original Name: {vndb_data['original_name']}\n"
+            if vndb_data.get('aliases'):
+                vndb_section += f"- Aliases: {', '.join(vndb_data['aliases'])}\n"
+            if vndb_data.get('description'):
+                vndb_section += f"- Description: {vndb_data['description']}\n"
+            if vndb_data.get('age'):
+                vndb_section += f"- Age: {vndb_data['age']}\n"
+            if vndb_data.get('birthday'):
+                vndb_section += f"- Birthday: {vndb_data['birthday']}\n"
+            if vndb_data.get('blood_type'):
+                vndb_section += f"- Blood Type: {vndb_data['blood_type']}\n"
+            if vndb_data.get('height'):
+                vndb_section += f"- Height: {vndb_data['height']}cm\n"
+            if vndb_data.get('weight'):
+                vndb_section += f"- Weight: {vndb_data['weight']}kg\n"
+            if vndb_data.get('bust') and vndb_data.get('waist') and vndb_data.get('hips'):
+                vndb_section += f"- Measurements: {vndb_data['bust']}-{vndb_data['waist']}-{vndb_data['hips']}cm\n"
+            if vndb_data.get('hair'):
+                vndb_section += f"- Hair: {vndb_data['hair']}\n"
+            if vndb_data.get('eyes'):
+                vndb_section += f"- Eyes: {vndb_data['eyes']}\n"
+            if vndb_data.get('body'):
+                vndb_section += f"- Body Type: {vndb_data['body']}\n"
+            if vndb_data.get('clothes'):
+                vndb_section += f"- Clothes: {vndb_data['clothes']}\n"
+            if vndb_data.get('items'):
+                vndb_section += f"- Items: {vndb_data['items']}\n"
+            if vndb_data.get('role'):
+                vndb_section += f"- Role: {vndb_data['role']}\n"
+            if vndb_data.get('voiced_by'):
+                vndb_section += f"- Voiced by: {vndb_data['voiced_by']}\n"
+            if vndb_data.get('traits'):
+                vndb_section += f"- Traits: {', '.join(vndb_data['traits'])}\n"
+            if vndb_data.get('vns'):
+                games = vndb_data['vns'][:3]
+                vndb_section += f"- Visual Novels: {', '.join(games)}\n"
+            system_prompt += vndb_section
+
+        messages = [
+            {
+                "role": "system",
+                "content": system_prompt
+            },
+            {
+                "role": "user",
+                "content": f"Please analyze and summarize the following content, focusing exclusively on the character '{role_name}'. Save your summary to: {output_file_path}\n\nContent:\n{content}"
+            }
+        ]
+
+        return self.send_message(messages, tools)
         
+        system_prompt = f"""You are a professional skills folder generator.
+Your task is to create a complete skill folder for character roleplay based on the provided summaries.
+
+CHARACTER NAME: {role_name}
+
+Follow these skill design principles:
+- Keep SKILL.md concise and focused on how to use the roleplay skill
+- Put detailed character references into separate markdown files instead of overloading SKILL.md
+- Base every file on evidence from the summaries and reference data
+- Do not invent private, explicit, or unsupported details
+- Keep the output professional, public-safe, and reusable
+
+FOLDER STRUCTURE:
+Create exactly ONE folder: {role_name}-skill-main/
+
+REQUIRED FILES:
+
+1. SKILL.md
+- This is the entry point of the skill
+- It must contain ONLY YAML frontmatter with `name` and `description`
+- The description must clearly state what the skill does and when to use it
+- The body should be procedural and concise, telling the model to roleplay as the character directly
+- The body should explicitly reference the detailed files in `resource/` and explain what each file is for
+- Do not duplicate long reference material inside SKILL.md
+
+Expected structure:
+```markdown
+---
+name: {role_name}-perspective
+description: Character roleplay skill for {role_name}. Use when the user wants responses in {role_name}'s voice, mindset, behavior style, and conversational patterns. The skill should answer directly in character, preserve the user's language, and rely on resource files for detailed personality, speech, relationship, and life-event references.
+---
+
+# {role_name}
+
+## Roleplay Rules
+- Answer directly as {role_name}
+- Use first-person voice instead of third-person analysis unless the user explicitly asks for analysis
+- Match the user's language exactly
+- Stay in character unless the user explicitly asks to exit roleplay
+
+## Resource Map
+- Read `soul.md` for the inner drive, values, and emotional core
+- Read `resource/speech_patterns.md` for verbal style and phrasing habits
+- Read `resource/behavior_guide.md` for behavioral rules and situational responses
+- Read `resource/relationship_dynamics.md` for important relationship dynamics with other characters
+- Read `resource/key_life_events.md` for major experiences, turning points, and memory anchors
+- Read `limit.md` for boundaries and unsupported areas
+
+## Usage Notes
+- Prioritize consistent voice, worldview, and behavior over plot recitation
+- When facts are uncertain, stay within the strongest evidence from the summaries
+```
+
+2. soul.md
+- Summarize the character's inner core
+- Focus on motivation, values, fears, contradictions, attachments, and emotional center
+- Keep it interpretive but evidence-based
+
+Suggested sections:
+```markdown
+# Soul of {role_name}
+
+## Core Drive
+## Values and Beliefs
+## Emotional Core
+## Inner Contradictions
+## Growth Arc
+```
+
+3. limit.md
+- Define guardrails for the roleplay skill
+- Include unsupported topics, evidence limits, and tone boundaries
+- State that unsupported facts must not be invented
+
+Suggested sections:
+```markdown
+# Limitations
+
+## Scope Boundaries
+## Evidence Rules
+## Topic Restrictions
+## Roleplay Exit Conditions
+```
+
+4. resource/behavior_guide.md
+- Required
+- Describe repeatable behavior rules, habits, reactions, and situational defaults
+
+5. resource/speech_patterns.md
+- Required
+- Describe speech rhythm, wording, sentence habits, address patterns, tone shifts, and sample expression patterns
+
+6. resource/relationship_dynamics.md
+- Required
+- New reference file dedicated to important relationships with other characters
+- Include relationship type, emotional dynamic, behavior around that person, trust/conflict pattern, and why the relationship matters
+- Prefer structured sections per character or per relationship cluster
+
+7. resource/key_life_events.md
+- Required
+- New reference file dedicated to important life experiences and turning points
+- Include formative events, emotional impact, later behavioral influence, and what memories remain central to the persona
+- Organize chronologically when possible
+
+RESOURCE WRITING RULES:
+- Each reference file should focus on one domain only
+- Avoid repeating the same paragraphs across files
+- Prefer bullet lists and compact sections over long prose
+- Make the files useful as references for future roleplay, not as literary essays
+
+IMPORTANT INSTRUCTIONS:
+1. Use the write_file tool multiple times if needed
+2. Create all seven required files:
+   - {role_name}-skill-main/SKILL.md
+   - {role_name}-skill-main/soul.md
+   - {role_name}-skill-main/limit.md
+   - {role_name}-skill-main/resource/behavior_guide.md
+   - {role_name}-skill-main/resource/speech_patterns.md
+   - {role_name}-skill-main/resource/relationship_dynamics.md
+   - {role_name}-skill-main/resource/key_life_events.md
+3. Use valid markdown in every file
+4. Keep SKILL.md lean; move detail into resource files
+5. Focus on PUBLIC PERSONA, THINKING STYLE, SPEECH PATTERNS, RELATIONSHIPS, and IMPORTANT EXPERIENCES
+6. Base all content on the summaries and reference data only
+7. Do not create alternative versions or extra folders unless explicitly necessary
+
+Use the write_file tool to create all required files."""
+
         if output_language:
             lang_names = {"zh": "中文", "en": "English", "ja": "日本語"}
             lang_name = lang_names.get(output_language, output_language)
@@ -747,6 +942,68 @@ IMPORTANT INSTRUCTIONS:
 
 Use the write_file tool to create all necessary files. You may call it multiple times."""
 
+        system_prompt = f"""You are a professional skills folder generator.
+Your task is to create a complete skill folder for character roleplay based on compacted character summaries and reference data.
+
+CHARACTER NAME: {role_name}
+
+CONTENT GUIDELINES:
+- Keep content appropriate, professional, and reusable
+- Focus on personality, speech patterns, thinking style, relationship dynamics, and important life events
+- Do not invent unsupported or overly private details
+- Treat the provided summaries as compact evidence, not complete raw source text
+
+FOLDER STRUCTURE:
+Create exactly one folder: {role_name}-skill-main/
+
+REQUIRED FILES:
+1. SKILL.md
+2. soul.md
+3. limit.md
+4. resource/behavior_guide.md
+5. resource/speech_patterns.md
+6. resource/relationship_dynamics.md
+7. resource/key_life_events.md
+
+SKILL.md REQUIREMENTS:
+- Use only `name` and `description` in YAML frontmatter
+- Keep `description` short: 1 to 2 sentences only
+- Limit `description` to a compact trigger summary: what the skill does and when to use it
+- Do NOT put detailed resource relationships, read order, or file ownership rules into `description`
+- Move detailed trigger guidance, resource dependencies, read order, and usage rules into the markdown body
+- In the markdown body, explicitly define how SKILL.md depends on the other markdown files
+- Explain the relationship among the resource files, including which file owns which kind of information
+- State a clear read order or priority order for those files
+- In the markdown body, add a dedicated section such as `## Resource Map` or `## Resource Dependencies`
+- Make it clear that:
+  - `soul.md` owns inner motives, values, contradictions, and emotional core
+  - `resource/speech_patterns.md` owns phrasing, rhythm, vocabulary, and address habits
+  - `resource/behavior_guide.md` owns default reactions, habits, and situational behavior rules
+  - `resource/relationship_dynamics.md` owns how the character relates to specific people or groups
+  - `resource/key_life_events.md` owns formative experiences, turning points, and memory anchors
+  - `limit.md` defines boundaries, unsupported facts, and exit conditions
+- Keep SKILL.md lean and procedural; do not duplicate long reference content there
+- Example short description style:
+  - `Character roleplay skill for {role_name}. Use when the user wants replies in {role_name}'s voice and mindset.`
+
+RESOURCE FILE REQUIREMENTS:
+- `soul.md`: inner drive, beliefs, contradictions, emotional center, growth arc
+- `resource/speech_patterns.md`: speaking style, cadence, wording preferences, tone shifts, example phrasing patterns
+- `resource/behavior_guide.md`: habits, reactions, if-then behavior rules, social defaults, conflict/stress responses
+- `resource/relationship_dynamics.md`: relationship type, emotional tone, behavior toward others, trust/conflict pattern, why the relationship matters
+- `resource/key_life_events.md`: timeline anchors, formative experiences, emotional impact, long-term influence on current persona
+- `limit.md`: scope boundaries, evidence rules, restricted topics, roleplay exit conditions
+
+IMPORTANT INSTRUCTIONS:
+1. Use the write_file tool multiple times if needed
+2. Create all seven required files
+3. Use valid markdown in every file
+4. Base all content on the provided summaries and reference data only
+5. Do not create extra folders or alternative variants
+6. Ensure SKILL.md explicitly tells future readers how to use and combine all referenced markdown resources
+
+Use the write_file tool to create all required files."""
+
         if output_language:
             lang_names = {"zh": "中文", "en": "English", "ja": "日本語"}
             lang_name = lang_names.get(output_language, output_language)
@@ -754,7 +1011,7 @@ Use the write_file tool to create all necessary files. You may call it multiple 
 
 ## OUTPUT LANGUAGE REQUIREMENT
 You MUST write ALL content in {lang_name}.
-- SKILL.md, soul.md, limit.md: ALL in {lang_name}
+- SKILL.md, soul.md, limit.md, and all resource markdown files: ALL in {lang_name}
 - Character descriptions: {lang_name}
 - All instructions and content: {lang_name}
 ALL output must be in {lang_name}, regardless of the source text language."""
@@ -809,7 +1066,7 @@ ALL output must be in {lang_name}, regardless of the source text language."""
             },
             {
                 "role": "user",
-                "content": f"Please generate a complete skills folder for character '{role_name}' based on the following summaries:\n{summaries}\n\nRemember to create ALL required files for BOTH versions (code and full). You can call the write_file tool multiple times. After creating all files, indicate completion."
+                "content": f"Please generate a complete skill folder for character '{role_name}' based on the following compacted summaries:\n{summaries}\n\nCreate the single required folder structure exactly as specified. In SKILL.md, explicitly define the dependency and reading relationship between SKILL.md and the other markdown resources, including which file owns which type of information. You can call the write_file tool multiple times. After creating all required files, indicate completion."
             }
         ]
         

--- a/utils/llm_interaction.py
+++ b/utils/llm_interaction.py
@@ -1002,6 +1002,15 @@ IMPORTANT INSTRUCTIONS:
 5. Do not create extra folders or alternative variants
 6. Ensure SKILL.md explicitly tells future readers how to use and combine all referenced markdown resources
 
+## LANGUAGE REQUIREMENT
+By default, you MUST use the same language as the provided summaries and source material.
+- If the summaries are in Chinese, write all generated markdown in Chinese
+- If the summaries are in Japanese, write all generated markdown in Japanese
+- If the summaries are in English, write all generated markdown in English
+- Keep the language consistent across SKILL.md, soul.md, limit.md, and all resource markdown files
+- Do not mix languages unless the source material itself clearly does so
+- Preserve original-language character voice, terminology, and quoted phrasing style whenever possible
+
 Use the write_file tool to create all required files."""
 
         if output_language:


### PR DESCRIPTION
这次改动主要集中在两处：[main.py](/D:/workspace/python/GalgameCharacterSkills/main.py) 和 [utils/llm_interaction.py](/D:/workspace/python/GalgameCharacterSkills/utils/llm_interaction.py)。目标是两件事：一是让角色 skill 的生成提示更合理，二是解决大批 summary 进入模型时容易超上下文的问题，同时尽量保留有效信息。

**1. skill 生成逻辑的调整**
在 [utils/llm_interaction.py](/D:/workspace/python/GalgameCharacterSkills/utils/llm_interaction.py) 里，`generate_skills_folder_init()` 的 system prompt 被重新约束了。核心变化有这些：

- `SKILL.md` 的 `description` 被限制为短触发说明，只允许 1 到 2 句话，主要说明“这个 skill 做什么、什么时候用”。这避免 frontmatter 过长。
- 资源之间的依赖关系不再塞进 `description`，而是明确要求写到正文里，例如 `## Resource Map` 或 `## Resource Dependencies`。
- prompt 里明确规定了每个文件各自“负责什么信息”：
  - `soul.md` 负责内在动机、价值观、矛盾、情感核心
  - `resource/speech_patterns.md` 负责语言风格、节奏、措辞、称呼习惯
  - `resource/behavior_guide.md` 负责行为规则、默认反应、情境应对
  - `resource/relationship_dynamics.md` 负责人际关系动态
  - `resource/key_life_events.md` 负责关键经历、转折点、记忆锚点
  - `limit.md` 负责边界和禁区
- 新 prompt 还要求 `SKILL.md` 写出“读取顺序/优先级”，也就是未来使用这个 skill 的模型应当如何组合这些资源。


**2. 大上下文 summary 的处理策略**
在 [main.py](/D:/workspace/python/GalgameCharacterSkills/main.py) 里，`generate_skills_folder()` 原来是把所有 summary 文件全文拼接后直接发给模型。这会在 summary 很多时直接撞上上下文上限。现在改成了分级策略：

- 新增了 `_build_full_skill_generation_context()`，用来构造“完整上下文”。
- 新增了 `_estimate_tokens_from_text()`，用字符数做一个保守 token 估算，便于本地判断是否可能超限。
- 现在流程是：
  - 先把所有 summary 全文拼起来
  - 先估算完整输入的 token
  - 如果估算值不超过 `128000`，就直接使用完整上下文，不压缩
  - 只有超过 `128000`，才进入压缩模式
- 压缩模式的目标预算被设成大约 `100000` token，对应约 `200000` 字符，不再像之前那样默认强压缩。

**3. 压缩策略本身的演进**
压缩策略现在不是简单截断，而是做了分层保留，主要在 [main.py](/D:/workspace/python/GalgameCharacterSkills/main.py) 里这些辅助函数完成：

- `_extract_summary_highlights()`：提取标题、列表、引用、表格等高信息密度内容。
- `_extract_key_sections()`：优先抓取带关键章节标题的整段内容，比如“核心”“关系”“经历”“人格”“行为”“背景”“成长”等。
- `_head_tail_weighted_order()`：把 summary 文件按原始顺序做“头 1 尾 2”的加权抽取顺序。
- `_build_prioritized_skill_generation_context()`：真正执行压缩时的主策略。

现在超限后的保留顺序是：

1. 按原始 summary 顺序做“头 1、尾 2”循环抽取  
2. 被抽中的文件优先保留全文  
3. 其余文件优先保留关键章节整段  
4. 最后剩余内容才做普通摘要压缩  

这比单纯按修改时间取最近文件更符合剧情型资料的结构，因为很多 galgame 角色总结往往前段是基础设定，后段是最终成长、结局或后期变化，头尾都重要，而中段通常更适合摘要化。
